### PR TITLE
Add AudioRecorder iOS app (V1)

### DIFF
--- a/AudioRecorder/AudioRecorder.xcodeproj/project.pbxproj
+++ b/AudioRecorder/AudioRecorder.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		FACE000000000000000054AB /* RecordingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingManager.swift; sourceTree = "<group>"; };
 		FACE000000000000000055AB /* Recording.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Recording.swift; sourceTree = "<group>"; };
 		FACE000000000000000056AB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		FACE000000000000000057AB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -56,6 +57,7 @@
 				FACE000000000000000054AB /* RecordingManager.swift */,
 				FACE000000000000000055AB /* Recording.swift */,
 				FACE000000000000000056AB /* Assets.xcassets */,
+				FACE000000000000000057AB /* Info.plist */,
 			);
 			path = AudioRecorder;
 			sourceTree = "<group>";
@@ -273,12 +275,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_NSMicrophoneUsageDescription = "AudioRecorder needs microphone access to record audio.";
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_FILE = AudioRecorder/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -300,12 +297,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_NSMicrophoneUsageDescription = "AudioRecorder needs microphone access to record audio.";
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_FILE = AudioRecorder/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/AudioRecorder/AudioRecorder.xcodeproj/project.pbxproj
+++ b/AudioRecorder/AudioRecorder.xcodeproj/project.pbxproj
@@ -1,0 +1,347 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		FACE000000000000000060AB /* AudioRecorderApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACE000000000000000050AB /* AudioRecorderApp.swift */; };
+		FACE000000000000000061AB /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACE000000000000000051AB /* ContentView.swift */; };
+		FACE000000000000000062AB /* RecordingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACE000000000000000052AB /* RecordingView.swift */; };
+		FACE000000000000000063AB /* StoredRecordingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACE000000000000000053AB /* StoredRecordingsView.swift */; };
+		FACE000000000000000064AB /* RecordingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACE000000000000000054AB /* RecordingManager.swift */; };
+		FACE000000000000000065AB /* Recording.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACE000000000000000055AB /* Recording.swift */; };
+		FACE000000000000000066AB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FACE000000000000000056AB /* Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		FACE000000000000000040AB /* AudioRecorder.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AudioRecorder.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		FACE000000000000000050AB /* AudioRecorderApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderApp.swift; sourceTree = "<group>"; };
+		FACE000000000000000051AB /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		FACE000000000000000052AB /* RecordingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingView.swift; sourceTree = "<group>"; };
+		FACE000000000000000053AB /* StoredRecordingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredRecordingsView.swift; sourceTree = "<group>"; };
+		FACE000000000000000054AB /* RecordingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingManager.swift; sourceTree = "<group>"; };
+		FACE000000000000000055AB /* Recording.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Recording.swift; sourceTree = "<group>"; };
+		FACE000000000000000056AB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		FACE000000000000000022AB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		FACE000000000000000030AB = {
+			isa = PBXGroup;
+			children = (
+				FACE000000000000000031AB /* AudioRecorder */,
+				FACE000000000000000032AB /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		FACE000000000000000031AB /* AudioRecorder */ = {
+			isa = PBXGroup;
+			children = (
+				FACE000000000000000050AB /* AudioRecorderApp.swift */,
+				FACE000000000000000051AB /* ContentView.swift */,
+				FACE000000000000000052AB /* RecordingView.swift */,
+				FACE000000000000000053AB /* StoredRecordingsView.swift */,
+				FACE000000000000000054AB /* RecordingManager.swift */,
+				FACE000000000000000055AB /* Recording.swift */,
+				FACE000000000000000056AB /* Assets.xcassets */,
+			);
+			path = AudioRecorder;
+			sourceTree = "<group>";
+		};
+		FACE000000000000000032AB /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				FACE000000000000000040AB /* AudioRecorder.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		FACE000000000000000010AB /* AudioRecorder */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FACE000000000000000011AB /* Build configuration list for PBXNativeTarget "AudioRecorder" */;
+			buildPhases = (
+				FACE000000000000000020AB /* Sources */,
+				FACE000000000000000021AB /* Resources */,
+				FACE000000000000000022AB /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = AudioRecorder;
+			productName = AudioRecorder;
+			productReference = FACE000000000000000040AB /* AudioRecorder.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		FACE000000000000000001AB /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					FACE000000000000000010AB = {
+						CreatedOnToolsVersion = 15.0;
+					};
+				};
+			};
+			buildConfigurationList = FACE000000000000000002AB /* Build configuration list for PBXProject "AudioRecorder" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = FACE000000000000000030AB;
+			productRefGroup = FACE000000000000000032AB /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				FACE000000000000000010AB /* AudioRecorder */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		FACE000000000000000021AB /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FACE000000000000000066AB /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		FACE000000000000000020AB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FACE000000000000000060AB /* AudioRecorderApp.swift in Sources */,
+				FACE000000000000000061AB /* ContentView.swift in Sources */,
+				FACE000000000000000062AB /* RecordingView.swift in Sources */,
+				FACE000000000000000063AB /* StoredRecordingsView.swift in Sources */,
+				FACE000000000000000064AB /* RecordingManager.swift in Sources */,
+				FACE000000000000000065AB /* Recording.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		FACE000000000000000003AB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		FACE000000000000000004AB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		FACE000000000000000012AB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "AudioRecorder needs microphone access to record audio.";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.audiorecorder.app;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		FACE000000000000000013AB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "AudioRecorder needs microphone access to record audio.";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.audiorecorder.app;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		FACE000000000000000002AB /* Build configuration list for PBXProject "AudioRecorder" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FACE000000000000000003AB /* Debug */,
+				FACE000000000000000004AB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FACE000000000000000011AB /* Build configuration list for PBXNativeTarget "AudioRecorder" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FACE000000000000000012AB /* Debug */,
+				FACE000000000000000013AB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+	};
+	rootObject = FACE000000000000000001AB /* Project object */;
+}

--- a/AudioRecorder/AudioRecorder/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/AudioRecorder/AudioRecorder/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/AudioRecorder/AudioRecorder/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/AudioRecorder/AudioRecorder/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/AudioRecorder/AudioRecorder/Assets.xcassets/Contents.json
+++ b/AudioRecorder/AudioRecorder/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/AudioRecorder/AudioRecorder/AudioRecorderApp.swift
+++ b/AudioRecorder/AudioRecorder/AudioRecorderApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct AudioRecorderApp: App {
+    @StateObject private var recordingManager = RecordingManager()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(recordingManager)
+        }
+    }
+}

--- a/AudioRecorder/AudioRecorder/ContentView.swift
+++ b/AudioRecorder/AudioRecorder/ContentView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        TabView {
+            RecordingView()
+                .tabItem {
+                    Label("Record", systemImage: "mic")
+                }
+
+            StoredRecordingsView()
+                .tabItem {
+                    Label("Recordings", systemImage: "list.bullet")
+                }
+        }
+    }
+}

--- a/AudioRecorder/AudioRecorder/Info.plist
+++ b/AudioRecorder/AudioRecorder/Info.plist
@@ -2,6 +2,24 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>AudioRecorder</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>AudioRecorder needs microphone access to record audio.</string>
 	<key>UIBackgroundModes</key>

--- a/AudioRecorder/AudioRecorder/Info.plist
+++ b/AudioRecorder/AudioRecorder/Info.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>AudioRecorder needs microphone access to record audio.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/AudioRecorder/AudioRecorder/Recording.swift
+++ b/AudioRecorder/AudioRecorder/Recording.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+struct Recording: Identifiable, Codable {
+    let id: UUID
+    let filename: String
+    var title: String
+    let date: Date
+    var duration: TimeInterval
+
+    var url: URL {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent(filename)
+    }
+
+    var formattedDate: String {
+        let f = DateFormatter()
+        f.dateStyle = .medium
+        f.timeStyle = .short
+        return f.string(from: date)
+    }
+
+    var formattedDuration: String {
+        let m = Int(duration) / 60
+        let s = Int(duration) % 60
+        return String(format: "%d:%02d", m, s)
+    }
+
+    static func autoTitle(for date: Date) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "MMM d, h:mma"
+        return f.string(from: date)
+    }
+}

--- a/AudioRecorder/AudioRecorder/RecordingManager.swift
+++ b/AudioRecorder/AudioRecorder/RecordingManager.swift
@@ -7,6 +7,7 @@ class RecordingManager: NSObject, ObservableObject {
     @Published var recordings: [Recording] = []
 
     @Published var playingID: UUID? = nil
+    @Published var isPlaybackPaused = false
     @Published var playbackTime: TimeInterval = 0
     @Published var playbackDuration: TimeInterval = 0
 
@@ -101,6 +102,7 @@ class RecordingManager: NSObject, ObservableObject {
             audioPlayer?.play()
 
             playingID = recording.id
+            isPlaybackPaused = false
             playbackTime = 0
             playbackDuration = audioPlayer?.duration ?? recording.duration
             startPlaybackTimer()
@@ -112,7 +114,13 @@ class RecordingManager: NSObject, ObservableObject {
     func pausePlayback() {
         audioPlayer?.pause()
         playbackTimer?.invalidate()
-        playingID = nil
+        isPlaybackPaused = true
+    }
+
+    func resumePlayback() {
+        audioPlayer?.play()
+        isPlaybackPaused = false
+        startPlaybackTimer()
     }
 
     func stopPlayback() {
@@ -120,7 +128,15 @@ class RecordingManager: NSObject, ObservableObject {
         audioPlayer = nil
         playbackTimer?.invalidate()
         playingID = nil
+        isPlaybackPaused = false
         playbackTime = 0
+    }
+
+    func skip(by seconds: TimeInterval) {
+        guard let player = audioPlayer else { return }
+        let newTime = max(0, min(player.currentTime + seconds, player.duration))
+        player.currentTime = newTime
+        playbackTime = newTime
     }
 
     // MARK: - CRUD
@@ -173,6 +189,7 @@ extension RecordingManager: AVAudioPlayerDelegate {
     func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
         playbackTimer?.invalidate()
         playingID = nil
+        isPlaybackPaused = false
         playbackTime = 0
     }
 }

--- a/AudioRecorder/AudioRecorder/RecordingManager.swift
+++ b/AudioRecorder/AudioRecorder/RecordingManager.swift
@@ -1,0 +1,178 @@
+import AVFoundation
+
+class RecordingManager: NSObject, ObservableObject {
+    @Published var isRecording = false
+    @Published var isPaused = false
+    @Published var recordingTime: TimeInterval = 0
+    @Published var recordings: [Recording] = []
+
+    @Published var playingID: UUID? = nil
+    @Published var playbackTime: TimeInterval = 0
+    @Published var playbackDuration: TimeInterval = 0
+
+    private var audioRecorder: AVAudioRecorder?
+    private var audioPlayer: AVAudioPlayer?
+    private var recordingTimer: Timer?
+    private var playbackTimer: Timer?
+
+    override init() {
+        super.init()
+        loadRecordings()
+    }
+
+    // MARK: - Recording
+
+    func startRecording() {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(.playAndRecord, mode: .default, options: .defaultToSpeaker)
+            try session.setActive(true)
+
+            let filename = "recording_\(Date().timeIntervalSince1970).m4a"
+            let url = documentsURL().appendingPathComponent(filename)
+
+            let settings: [String: Any] = [
+                AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
+                AVSampleRateKey: 44100,
+                AVNumberOfChannelsKey: 1,
+                AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
+            ]
+
+            audioRecorder = try AVAudioRecorder(url: url, settings: settings)
+            audioRecorder?.record()
+
+            isRecording = true
+            isPaused = false
+            recordingTime = 0
+            startRecordingTimer()
+        } catch {
+            print("Recording failed: \(error)")
+        }
+    }
+
+    func pauseRecording() {
+        audioRecorder?.pause()
+        isPaused = true
+        recordingTimer?.invalidate()
+    }
+
+    func resumeRecording() {
+        audioRecorder?.record()
+        isPaused = false
+        startRecordingTimer()
+    }
+
+    func finishRecording() {
+        guard let recorder = audioRecorder else { return }
+
+        let url = recorder.url
+        let duration = recorder.currentTime
+        let now = Date()
+
+        recorder.stop()
+        recordingTimer?.invalidate()
+
+        let recording = Recording(
+            id: UUID(),
+            filename: url.lastPathComponent,
+            title: Recording.autoTitle(for: now),
+            date: now,
+            duration: duration
+        )
+        recordings.insert(recording, at: 0)
+        saveRecordings()
+
+        isRecording = false
+        isPaused = false
+        recordingTime = 0
+        audioRecorder = nil
+    }
+
+    // MARK: - Playback
+
+    func play(_ recording: Recording) {
+        stopPlayback()
+        do {
+            try AVAudioSession.sharedInstance().setCategory(.playback)
+            try AVAudioSession.sharedInstance().setActive(true)
+
+            audioPlayer = try AVAudioPlayer(contentsOf: recording.url)
+            audioPlayer?.delegate = self
+            audioPlayer?.play()
+
+            playingID = recording.id
+            playbackTime = 0
+            playbackDuration = audioPlayer?.duration ?? recording.duration
+            startPlaybackTimer()
+        } catch {
+            print("Playback failed: \(error)")
+        }
+    }
+
+    func pausePlayback() {
+        audioPlayer?.pause()
+        playbackTimer?.invalidate()
+        playingID = nil
+    }
+
+    func stopPlayback() {
+        audioPlayer?.stop()
+        audioPlayer = nil
+        playbackTimer?.invalidate()
+        playingID = nil
+        playbackTime = 0
+    }
+
+    // MARK: - CRUD
+
+    func updateTitle(for id: UUID, title: String) {
+        guard let i = recordings.firstIndex(where: { $0.id == id }) else { return }
+        recordings[i].title = title
+        saveRecordings()
+    }
+
+    func delete(_ recording: Recording) {
+        if playingID == recording.id { stopPlayback() }
+        try? FileManager.default.removeItem(at: recording.url)
+        recordings.removeAll { $0.id == recording.id }
+        saveRecordings()
+    }
+
+    // MARK: - Private
+
+    private func startRecordingTimer() {
+        recordingTimer = Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { [weak self] _ in
+            self?.recordingTime = self?.audioRecorder?.currentTime ?? 0
+        }
+    }
+
+    private func startPlaybackTimer() {
+        playbackTimer = Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { [weak self] _ in
+            self?.playbackTime = self?.audioPlayer?.currentTime ?? 0
+        }
+    }
+
+    private func documentsURL() -> URL {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+    }
+
+    private func saveRecordings() {
+        if let data = try? JSONEncoder().encode(recordings) {
+            UserDefaults.standard.set(data, forKey: "recordings")
+        }
+    }
+
+    private func loadRecordings() {
+        guard let data = UserDefaults.standard.data(forKey: "recordings"),
+              let decoded = try? JSONDecoder().decode([Recording].self, from: data) else { return }
+        recordings = decoded
+    }
+}
+
+extension RecordingManager: AVAudioPlayerDelegate {
+    func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        playbackTimer?.invalidate()
+        playingID = nil
+        playbackTime = 0
+    }
+}

--- a/AudioRecorder/AudioRecorder/RecordingView.swift
+++ b/AudioRecorder/AudioRecorder/RecordingView.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+
+struct RecordingView: View {
+    @EnvironmentObject var manager: RecordingManager
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                Spacer()
+                timerDisplay
+                Spacer()
+                controls
+                    .padding(.bottom, 64)
+            }
+            .navigationTitle("Record")
+        }
+    }
+
+    private var timerDisplay: some View {
+        Text(formatTime(manager.recordingTime))
+            .font(.system(size: 72, weight: .thin, design: .monospaced))
+            .foregroundStyle(manager.isRecording && !manager.isPaused ? .red : .secondary)
+            .contentTransition(.numericText())
+            .animation(.linear(duration: 0.05), value: manager.recordingTime)
+    }
+
+    @ViewBuilder
+    private var controls: some View {
+        if manager.isRecording {
+            HStack(spacing: 52) {
+                circleButton(
+                    icon: manager.isPaused ? "play.fill" : "pause.fill",
+                    background: Color(.systemGray5),
+                    foreground: .primary,
+                    size: 76
+                ) {
+                    if manager.isPaused {
+                        manager.resumeRecording()
+                    } else {
+                        manager.pauseRecording()
+                    }
+                }
+
+                circleButton(
+                    icon: "checkmark",
+                    background: .green,
+                    foreground: .white,
+                    size: 76
+                ) {
+                    manager.finishRecording()
+                }
+            }
+        } else {
+            circleButton(
+                icon: "mic.fill",
+                background: .red,
+                foreground: .white,
+                size: 100
+            ) {
+                manager.startRecording()
+            }
+            .shadow(color: .red.opacity(0.4), radius: 16, y: 8)
+        }
+    }
+
+    private func circleButton(
+        icon: String,
+        background: Color,
+        foreground: Color,
+        size: CGFloat,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Circle()
+                .fill(background)
+                .frame(width: size, height: size)
+                .overlay {
+                    Image(systemName: icon)
+                        .font(.system(size: size * 0.38, weight: .medium))
+                        .foregroundStyle(foreground)
+                }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func formatTime(_ t: TimeInterval) -> String {
+        let m = Int(t) / 60
+        let s = Int(t) % 60
+        let ds = Int((t * 10).truncatingRemainder(dividingBy: 10))
+        return String(format: "%02d:%02d.%d", m, s, ds)
+    }
+}

--- a/AudioRecorder/AudioRecorder/RecordingView.swift
+++ b/AudioRecorder/AudioRecorder/RecordingView.swift
@@ -86,7 +86,6 @@ struct RecordingView: View {
     private func formatTime(_ t: TimeInterval) -> String {
         let m = Int(t) / 60
         let s = Int(t) % 60
-        let ds = Int((t * 10).truncatingRemainder(dividingBy: 10))
-        return String(format: "%d:%d.%d", m, s, ds)
+        return String(format: "%d:%02d", m, s)
     }
 }

--- a/AudioRecorder/AudioRecorder/RecordingView.swift
+++ b/AudioRecorder/AudioRecorder/RecordingView.swift
@@ -87,6 +87,6 @@ struct RecordingView: View {
         let m = Int(t) / 60
         let s = Int(t) % 60
         let ds = Int((t * 10).truncatingRemainder(dividingBy: 10))
-        return String(format: "%02d:%02d.%d", m, s, ds)
+        return String(format: "%d:%d.%d", m, s, ds)
     }
 }

--- a/AudioRecorder/AudioRecorder/StoredRecordingsView.swift
+++ b/AudioRecorder/AudioRecorder/StoredRecordingsView.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+
+struct StoredRecordingsView: View {
+    @EnvironmentObject var manager: RecordingManager
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if manager.recordings.isEmpty {
+                    ContentUnavailableView(
+                        "No Recordings",
+                        systemImage: "mic.slash",
+                        description: Text("Your recordings will appear here")
+                    )
+                } else {
+                    List {
+                        ForEach(manager.recordings) { recording in
+                            RecordingRow(recording: recording)
+                        }
+                        .onDelete { indexSet in
+                            let toDelete = indexSet.map { manager.recordings[$0] }
+                            toDelete.forEach { manager.delete($0) }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Recordings")
+        }
+    }
+}
+
+struct RecordingRow: View {
+    @EnvironmentObject var manager: RecordingManager
+    let recording: Recording
+
+    @State private var title = ""
+    @FocusState private var isFocused: Bool
+
+    private var isPlaying: Bool { manager.playingID == recording.id }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            TextField("Title", text: $title)
+                .font(.headline)
+                .focused($isFocused)
+                .onSubmit { commitTitle() }
+                .onChange(of: isFocused) { _, focused in
+                    if !focused { commitTitle() }
+                }
+
+            HStack(spacing: 4) {
+                Text(recording.formattedDate)
+                Text("·")
+                Text(recording.formattedDuration)
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+            if isPlaying {
+                PlaybackBar()
+                    .padding(.top, 2)
+            }
+
+            HStack {
+                Button(action: handlePlayPause) {
+                    Label(
+                        isPlaying ? "Pause" : "Play",
+                        systemImage: isPlaying ? "pause.circle.fill" : "play.circle.fill"
+                    )
+                    .font(.subheadline.weight(.medium))
+                }
+
+                Spacer()
+
+                ShareLink(item: recording.url) {
+                    Image(systemName: "square.and.arrow.up")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.top, 2)
+        }
+        .padding(.vertical, 6)
+        .onAppear { title = recording.title }
+    }
+
+    private func handlePlayPause() {
+        if isPlaying {
+            manager.pausePlayback()
+        } else {
+            manager.play(recording)
+        }
+    }
+
+    private func commitTitle() {
+        let trimmed = title.trimmingCharacters(in: .whitespaces)
+        if !trimmed.isEmpty {
+            manager.updateTitle(for: recording.id, title: trimmed)
+        } else {
+            title = recording.title
+        }
+    }
+}
+
+struct PlaybackBar: View {
+    @EnvironmentObject var manager: RecordingManager
+
+    private var progress: Double {
+        guard manager.playbackDuration > 0 else { return 0 }
+        return min(manager.playbackTime / manager.playbackDuration, 1.0)
+    }
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(Color(.systemGray4))
+                    .frame(height: 3)
+                Capsule()
+                    .fill(Color.accentColor)
+                    .frame(width: geo.size.width * progress, height: 3)
+            }
+        }
+        .frame(height: 3)
+    }
+}

--- a/AudioRecorder/AudioRecorder/StoredRecordingsView.swift
+++ b/AudioRecorder/AudioRecorder/StoredRecordingsView.swift
@@ -30,6 +30,7 @@ struct RecordingRow: View {
     let recording: Recording
 
     @State private var title = ""
+    @State private var confirmDelete = false
     @FocusState private var isFocused: Bool
 
     private var isActive: Bool { manager.playingID == recording.id }
@@ -58,28 +59,40 @@ struct RecordingRow: View {
                     .padding(.vertical, 4)
             }
 
-            HStack {
-                Spacer()
-                controlButton("gobackward.10", enabled: isActive) { manager.skip(by: -10) }
-                Spacer()
-                Button(action: handlePlayPause) {
-                    Image(systemName: isPlaying ? "pause.circle.fill" : "play.circle.fill")
-                        .font(.system(size: 36))
+            HStack(spacing: 0) {
+                // Playback controls group
+                HStack(spacing: 0) {
+                    Spacer()
+                    controlButton("gobackward.10", enabled: isActive) { manager.skip(by: -10) }
+                    Spacer()
+                    Button(action: handlePlayPause) {
+                        Image(systemName: isPlaying ? "pause.circle.fill" : "play.circle.fill")
+                            .font(.system(size: 36))
+                    }
+                    Spacer()
+                    controlButton("goforward.10", enabled: isActive) { manager.skip(by: 10) }
+                    Spacer()
+                    ShareLink(item: recording.url) {
+                        Image(systemName: "square.and.arrow.up")
+                            .font(.system(size: 20))
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
                 }
-                Spacer()
-                controlButton("goforward.10", enabled: isActive) { manager.skip(by: 10) }
-                Spacer()
-                controlButton("trash", color: .red) { manager.delete(recording) }
-                Spacer()
-                ShareLink(item: recording.url) {
-                    Image(systemName: "square.and.arrow.up")
-                        .font(.system(size: 20))
-                        .foregroundStyle(.secondary)
-                }
-                Spacer()
+
+                Divider()
+                    .padding(.horizontal, 12)
+
+                // Delete — isolated to avoid accidental taps
+                controlButton("trash", color: .red) { confirmDelete = true }
+                    .padding(.trailing, 8)
             }
             .buttonStyle(.borderless)
             .padding(.top, 4)
+            .confirmationDialog("Delete this recording?", isPresented: $confirmDelete, titleVisibility: .visible) {
+                Button("Delete", role: .destructive) { manager.delete(recording) }
+                Button("Cancel", role: .cancel) {}
+            }
         }
         .padding(.vertical, 6)
         .onAppear { title = recording.title }

--- a/AudioRecorder/AudioRecorder/StoredRecordingsView.swift
+++ b/AudioRecorder/AudioRecorder/StoredRecordingsView.swift
@@ -78,6 +78,7 @@ struct RecordingRow: View {
                 }
                 Spacer()
             }
+            .buttonStyle(.borderless)
             .padding(.top, 4)
         }
         .padding(.vertical, 6)

--- a/AudioRecorder/AudioRecorder/StoredRecordingsView.swift
+++ b/AudioRecorder/AudioRecorder/StoredRecordingsView.swift
@@ -17,10 +17,6 @@ struct StoredRecordingsView: View {
                         ForEach(manager.recordings) { recording in
                             RecordingRow(recording: recording)
                         }
-                        .onDelete { indexSet in
-                            let toDelete = indexSet.map { manager.recordings[$0] }
-                            toDelete.forEach { manager.delete($0) }
-                        }
                     }
                 }
             }
@@ -36,7 +32,8 @@ struct RecordingRow: View {
     @State private var title = ""
     @FocusState private var isFocused: Bool
 
-    private var isPlaying: Bool { manager.playingID == recording.id }
+    private var isActive: Bool { manager.playingID == recording.id }
+    private var isPlaying: Bool { isActive && !manager.isPlaybackPaused }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -56,29 +53,32 @@ struct RecordingRow: View {
             .font(.caption)
             .foregroundStyle(.secondary)
 
-            if isPlaying {
+            if isActive {
                 PlaybackBar()
-                    .padding(.top, 2)
+                    .padding(.vertical, 4)
             }
 
             HStack {
-                Button(action: handlePlayPause) {
-                    Label(
-                        isPlaying ? "Pause" : "Play",
-                        systemImage: isPlaying ? "pause.circle.fill" : "play.circle.fill"
-                    )
-                    .font(.subheadline.weight(.medium))
-                }
-
                 Spacer()
-
+                controlButton("gobackward.10", enabled: isActive) { manager.skip(by: -10) }
+                Spacer()
+                Button(action: handlePlayPause) {
+                    Image(systemName: isPlaying ? "pause.circle.fill" : "play.circle.fill")
+                        .font(.system(size: 36))
+                }
+                Spacer()
+                controlButton("goforward.10", enabled: isActive) { manager.skip(by: 10) }
+                Spacer()
+                controlButton("trash", color: .red) { manager.delete(recording) }
+                Spacer()
                 ShareLink(item: recording.url) {
                     Image(systemName: "square.and.arrow.up")
-                        .font(.subheadline)
+                        .font(.system(size: 20))
                         .foregroundStyle(.secondary)
                 }
+                Spacer()
             }
-            .padding(.top, 2)
+            .padding(.top, 4)
         }
         .padding(.vertical, 6)
         .onAppear { title = recording.title }
@@ -87,9 +87,26 @@ struct RecordingRow: View {
     private func handlePlayPause() {
         if isPlaying {
             manager.pausePlayback()
+        } else if isActive {
+            manager.resumePlayback()
         } else {
             manager.play(recording)
         }
+    }
+
+    @ViewBuilder
+    private func controlButton(
+        _ icon: String,
+        color: Color = .primary,
+        enabled: Bool = true,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .font(.system(size: 20))
+                .foregroundStyle(enabled ? color : Color(.systemGray3))
+        }
+        .disabled(!enabled)
     }
 
     private func commitTitle() {

--- a/AudioRecorder/icon.svg
+++ b/AudioRecorder/icon.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" width="1024" height="1024">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#C0392B"/>
+      <stop offset="100%" style="stop-color:#7B0D1E"/>
+    </linearGradient>
+    <linearGradient id="micGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#FFFFFF;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#F0F0F0;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="8" stdDeviation="16" flood-color="#000000" flood-opacity="0.25"/>
+    </filter>
+  </defs>
+
+  <!-- Background rounded rect -->
+  <rect width="1024" height="1024" rx="224" ry="224" fill="url(#bg)"/>
+
+  <!-- Subtle inner highlight -->
+  <rect width="1024" height="512" rx="224" ry="224" fill="white" opacity="0.04"/>
+
+  <!-- Mic body -->
+  <rect x="392" y="192" width="240" height="352" rx="120" ry="120"
+        fill="url(#micGrad)" filter="url(#shadow)"/>
+
+  <!-- Mic stand arc -->
+  <path d="M 312 512
+           A 200 200 0 0 0 712 512"
+        fill="none" stroke="white" stroke-width="52" stroke-linecap="round"
+        filter="url(#shadow)"/>
+
+  <!-- Stand vertical line -->
+  <line x1="512" y1="700" x2="512" y2="800"
+        stroke="white" stroke-width="52" stroke-linecap="round"/>
+
+  <!-- Base -->
+  <line x1="360" y1="800" x2="664" y2="800"
+        stroke="white" stroke-width="52" stroke-linecap="round"/>
+
+  <!-- Mic grille lines -->
+  <line x1="430" y1="340" x2="594" y2="340"
+        stroke="#C0392B" stroke-width="14" stroke-linecap="round" opacity="0.35"/>
+  <line x1="415" y1="390" x2="609" y2="390"
+        stroke="#C0392B" stroke-width="14" stroke-linecap="round" opacity="0.35"/>
+  <line x1="410" y1="440" x2="614" y2="440"
+        stroke="#C0392B" stroke-width="14" stroke-linecap="round" opacity="0.35"/>
+  <line x1="415" y1="490" x2="609" y2="490"
+        stroke="#C0392B" stroke-width="14" stroke-linecap="round" opacity="0.3"/>
+</svg>


### PR DESCRIPTION
## Summary
- SwiftUI iOS app with two tabs: Record and Recordings
- Record tab: big red mic button, pause/finish controls, live timer
- Recordings tab: inline-editable titles, playback with progress bar, rewind/skip 10s, share sheet, delete with confirmation
- Background audio support (recording continues when screen locks or app is backgrounded)
- iOS 17+, bundle ID `com.audiorecorder.app`

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnB9XkfL3venuyJ6eReL4h)_